### PR TITLE
Fix code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/theme/script.js
+++ b/assets/js/theme/script.js
@@ -1,6 +1,7 @@
 (function () {
     var $, isBuilder;
     var isJQuery = typeof jQuery == 'function';
+    var DOMPurify = require('dompurify');
     if (isJQuery) $ = jQuery;
     $ ? isBuilder = $('html').hasClass('is-builder')
     : isBuilder = document.querySelector('html').classList.contains('is-builder');
@@ -1126,7 +1127,8 @@
                     newVideo.setAttribute('controls', '')
                     newVideo.setAttribute('playsinline', '')
                     newVideo.setAttribute('loop', '');
-                    newVideo.setAttribute('src', videoURL);
+                    var sanitizedVideoURL = DOMPurify.sanitize(videoURL);
+                    newVideo.setAttribute('src', sanitizedVideoURL);
                     el.style.display = 'none';
                     newVideo.style.width = '100%';
                     el.after(newVideo);

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "path": "^0.12.7",
     "semver": "^7.6.3",
     "uuid": "^11.0.1",
-    "zlib": "^1.0.5"
+    "zlib": "^1.0.5",
+    "dompurify": "^3.2.1"
   },
   "//": [
     "micromatch is an unspecified dependency of ava"


### PR DESCRIPTION
Fixes [https://github.com/Shiangan/shiangan.github.io/security/code-scanning/13](https://github.com/Shiangan/shiangan.github.io/security/code-scanning/13)

To fix the problem, we need to ensure that the `videoURL` is properly sanitized before it is used in the `src` attribute of the `video` element. This can be achieved by using a library like DOMPurify to sanitize the URL, ensuring that any potentially malicious content is removed.

1. Import the DOMPurify library.
2. Sanitize the `videoURL` before using it in the `src` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
